### PR TITLE
Added hovering effect for GuiTextWidget.

### DIFF
--- a/lib/gui/include/GuiTextWidget.hpp
+++ b/lib/gui/include/GuiTextWidget.hpp
@@ -27,6 +27,11 @@ public:
   void SetColor(const int r, const int g, const int b);
   void SetColor(const sf::Color &color);
 
+  void SetHoverCapture(bool enabled);
+
+  void SetHoverColor(const int r, const int g, const int b);
+  void SetHoverColor(const sf::Color &color);
+
   //
   // Signal & Slots
   //
@@ -40,6 +45,9 @@ private:
   sf::Font m_font;
   sf::Text m_text;
 
-  bool m_clicked;
+  sf::Color m_color;
+  sf::Color m_hoverColor;
+
+  bool m_hoverEffect;
 
 };

--- a/lib/gui/src/GuiTextWidget.cpp
+++ b/lib/gui/src/GuiTextWidget.cpp
@@ -28,7 +28,10 @@ GuiTextWidget::GuiTextWidget(Window* window)
   m_margins.left = 12.f;
   m_margins.right = 12.f;
 
-  m_clicked = false;
+  m_color = sf::Color(255, 255, 255);
+  m_hoverColor = sf::Color(230, 230, 230);
+
+  m_hoverEffect = false;
 }
 
 GuiTextWidget::~GuiTextWidget()
@@ -47,10 +50,19 @@ void GuiTextWidget::Update()
 
   if (m_text.getGlobalBounds().contains(mousePosition))
   {
+    if (m_hoverEffect)
+    {
+      m_text.setFillColor(m_hoverColor);
+    }
+
     if (EventHandler::GetInstance().GetMouseInput().IsMouseKeyReleased(MouseInput::MouseKey::Left))
     {
       Clicked();
     }
+  }
+  else
+  {
+    m_text.setFillColor(m_color);
   }
 }
 
@@ -90,12 +102,29 @@ void GuiTextWidget::SetText(const char *text)
 
 void GuiTextWidget::SetColor(const int r, const int g, const int b)
 {
-  m_text.setFillColor(sf::Color(r, g, b));
+  m_color = sf::Color(r, g, b);
+  m_text.setFillColor(m_color);
 }
 
 void GuiTextWidget::SetColor(const sf::Color &color)
 {
+  m_color = color;
   m_text.setFillColor(color);
+}
+
+void GuiTextWidget::SetHoverCapture(bool enabled)
+{
+  m_hoverEffect = enabled;
+}
+
+void GuiTextWidget::SetHoverColor(const int r, const int g, const int b)
+{
+  m_hoverColor = sf::Color(r, g, b);
+}
+
+void GuiTextWidget::SetHoverColor(const sf::Color &color)
+{
+  m_hoverColor = color;
 }
 
 void GuiTextWidget::draw(sf::RenderTarget &target, sf::RenderStates states) const


### PR DESCRIPTION
## Name 
Added hovering effect for GuiTextWidget.

## Description
Basic color for hovering effect is R: 230 G: 230 B: 230

## Changelog
* Added fields to handle basic and hover colors in GuiTextWidget.
* Removed unused m_click boolean field from GuiTextWidget.
* Added methods to set hover color.
* Added method to enable/disable hover effect.


## Reviewer
@mateuszpolec 