### PR TITLE
zmiana boost::format na std::format w metodzie ::GetCurrentResolutionString

### DIFF
--- a/src/core/src/Window/WindowResolution.cpp
+++ b/src/core/src/Window/WindowResolution.cpp
@@ -1,5 +1,5 @@
 #include <string>
-#include <boost/format.hpp>
+#include <format>
 
 #include "WindowResolution.hpp"
 
@@ -26,7 +26,7 @@ const sf::VideoMode &WindowResolution::GetCurrentResolution()
 
 const std::string WindowResolution::GetCurrentResolutionString()
 {
-  boost::format fmt = boost::format("%1% x %2%") 
+  std::format fmt = boost::format("%1% x %2%") 
                       % GetCurrentResolution().width 
                       % GetCurrentResolution().height;
 


### PR DESCRIPTION

## Name 

## Description

## Changelog
zmiana boost::format na std::format w metodzie ::GetCurrentResolutionString oraz #include<boost/format.hpp> na #inlcude<format> (wszystko znajduje się w klasie WindowResolution)
## Reviewer
@mateuszpolec 